### PR TITLE
Fix "addDays" extension returning wrong datetime when DST occurs on the result date

### DIFF
--- a/lib/date_time_extensions.dart
+++ b/lib/date_time_extensions.dart
@@ -1,0 +1,1 @@
+export 'src/date_time_extensions.dart';

--- a/lib/src/date_time_extensions.dart
+++ b/lib/src/date_time_extensions.dart
@@ -2,11 +2,11 @@ import 'package:flutter/foundation.dart';
 
 extension DateTimeExtensions on DateTime {
   DateTime get startOfDay {
-    return DateTime(year, month, day);
+    return (isUtc ? DateTime.utc : DateTime.new)(year, month, day);
   }
 
   DateTime get endOfDay {
-    return DateTime(
+    return (isUtc ? DateTime.utc : DateTime.new)(
       year,
       month,
       day,
@@ -19,8 +19,21 @@ extension DateTimeExtensions on DateTime {
     );
   }
 
+  /// Adds the provided [days] (positive or negative)
+  ///
+  /// This method takes care of Daylight Saving Time
   DateTime addDays(int days) {
-    return add(Duration(days: days));
+    return (isUtc ? DateTime.utc : DateTime.new)(
+      year,
+      month,
+      day + days,
+      hour,
+      minute,
+      second,
+      millisecond,
+      // setting the microseconds 999 moves the date to the next day on web
+      microsecond,
+    );
   }
 
   DateTime get startOfWeek {
@@ -48,6 +61,6 @@ extension DateTimeExtensions on DateTime {
   }
 
   bool isToday() {
-    return isSameDate(DateTime.now());
+    return isSameDate(isUtc ? DateTime.timestamp() : DateTime.now());
   }
 }

--- a/lib/src/p_calendar_controller.dart
+++ b/lib/src/p_calendar_controller.dart
@@ -5,11 +5,9 @@ class EventCalendarController extends ChangeNotifier {
     EventCalendarType type = EventCalendarType.week,
   }) : _viewType = type {
     _firstDayOfView = _firstDateBasedOnViewType(DateTime.now());
-    _timezoneOffset = _firstDayOfView.timeZoneOffset;
   }
 
   late DateTime _firstDayOfView;
-  late Duration _timezoneOffset;
 
   /// Returns the starting date for the current [viewType].
   DateTime get firstDayOfView => _firstDayOfView;
@@ -28,23 +26,19 @@ class EventCalendarController extends ChangeNotifier {
   RenderEventCalendar? _renderObject;
   void _attach(RenderEventCalendar renderObject) {
     renderObject._viewType = _viewType;
-
+    renderObject.date = _firstDayOfView;
     _renderObject = renderObject;
-    _renderObject?.markNeedsPaint();
+    renderObject.markNeedsPaint();
   }
 
   void jumpToPreviousPage() {
-    _firstDayOfView = _firstDayOfView.add(Duration(days: -_viewType.skipDays));
-    _correctFirstDateOfView();
-
+    _firstDayOfView = _firstDayOfView.addDays(-_viewType.skipDays);
     _renderObject?.date = firstDayOfView;
     notifyListeners();
   }
 
   void jumpToNextPage() {
-    _firstDayOfView = _firstDayOfView.add(Duration(days: _viewType.skipDays));
-    _correctFirstDateOfView();
-
+    _firstDayOfView = _firstDayOfView.addDays(_viewType.skipDays);
     _renderObject?.date = firstDayOfView;
     notifyListeners();
   }
@@ -59,15 +53,6 @@ class EventCalendarController extends ChangeNotifier {
     _firstDayOfView = _firstDateBasedOnViewType(date);
     _renderObject?.date = _firstDayOfView;
     notifyListeners();
-  }
-
-  /// Check if the timezone offset has changed and add the difference of the hours to [_firstDayOfView]
-  void _correctFirstDateOfView() {
-    if (_firstDayOfView.timeZoneOffset != _timezoneOffset) {
-      _firstDayOfView = _firstDayOfView
-          .add((_firstDayOfView.timeZoneOffset - _timezoneOffset).abs());
-      _timezoneOffset = _firstDayOfView.timeZoneOffset;
-    }
   }
 
   DateTime _firstDateBasedOnViewType(DateTime date) {


### PR DESCRIPTION
At 27th of October the clock goes back, so when using `addDays` extension it might result in incorrect value

Example

input: `2024-10-27T00:00:00Z`
calling: `addDays(1)` on the input will give
output: `2024-10-27T23:00:00Z`
expected: `2024-10-28T00:00:00Z`